### PR TITLE
Rename ActionDto from auth package to AuthActionDto

### DIFF
--- a/src/main/java/com/czertainly/api/model/core/auth/AuthActionDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/AuthActionDto.java
@@ -2,21 +2,17 @@ package com.czertainly.api.model.core.auth;
 
 import com.czertainly.api.model.common.NameAndUuidDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-public class ActionDto extends NameAndUuidDto {
+@Setter
+@Getter
+public class AuthActionDto extends NameAndUuidDto {
 
     @Schema(description = "Resource label", requiredMode = Schema.RequiredMode.REQUIRED)
     private String displayName;
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/czertainly/api/model/core/auth/AuthResourceDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/AuthResourceDto.java
@@ -28,7 +28,7 @@ public class AuthResourceDto extends NameAndUuidDto {
     private Boolean objectAccess;
 
     @Schema(description = "List of Actions for the Resource", requiredMode = Schema.RequiredMode.REQUIRED)
-    private List<ActionDto> actions;
+    private List<AuthActionDto> actions;
 
     @Override
     public String toString() {


### PR DESCRIPTION
- avoid confusion with ActionDto from workflow package
- workaround for bug in OpenAPI generator using wrong DTO in generated code